### PR TITLE
ENH: replace timsort with powersort

### DIFF
--- a/numpy/_core/src/npysort/timsort.cpp
+++ b/numpy/_core/src/npysort/timsort.cpp
@@ -58,6 +58,7 @@ compute_min_run(npy_intp num)
 typedef struct {
     npy_intp s; /* start pointer */
     npy_intp l; /* length */
+    int power;  /* run power for powersort merge ordering */
 } run;
 
 /* buffer for argsort. Declared here to avoid multiple declarations. */
@@ -383,60 +384,58 @@ merge_at_(type *arr, const run *stack, const npy_intp at, buffer_<Tag> *buffer)
     return 0;
 }
 
+/* See https://github.com/python/cpython/blob/ea23c897cd25702e72a04e06664f6864f07a7c5d/Objects/listsort.txt
+*  for a detailed explanation.
+*/
+static int
+powerloop(npy_intp s1, npy_intp n1, npy_intp n2, npy_intp n)
+{
+    int result = 0;
+    assert(s1 >= 0);
+    assert(n1 > 0 && n2 > 0);
+    assert(s1 + n1 + n2 <= n);
+    npy_intp a = 2 * s1 + n1;  /* 2*a */
+    npy_intp b = a + n1 + n2;  /* 2*b */
+    for (;;) {
+        ++result;
+        if (a >= n) {  /* both quotient bits are 1 */
+            assert(b >= a);
+            a -= n;
+            b -= n;
+        }
+        else if (b >= n) {  /* a/n bit is 0, b/n bit is 1 */
+            break;
+        }
+        assert(a < b && b < n);
+        a <<= 1;
+        b <<= 1;
+    }
+    return result;
+}
+
 template <typename Tag, typename type>
 static int
-try_collapse_(type *arr, run *stack, npy_intp *stack_ptr, buffer_<Tag> *buffer)
+found_new_run_(type *arr, run *stack, npy_intp *stack_ptr, npy_intp n2,
+               npy_intp total, buffer_<Tag> *buffer)
 {
     int ret;
-    npy_intp A, B, C, top;
-    top = *stack_ptr;
-
-    while (1 < top) {
-        B = stack[top - 2].l;
-        C = stack[top - 1].l;
-
-        if ((2 < top && stack[top - 3].l <= B + C) ||
-            (3 < top && stack[top - 4].l <= stack[top - 3].l + B)) {
-            A = stack[top - 3].l;
-
-            if (A <= C) {
-                ret = merge_at_<Tag>(arr, stack, top - 3, buffer);
-
-                if (NPY_UNLIKELY(ret < 0)) {
-                    return ret;
-                }
-
-                stack[top - 3].l += B;
-                stack[top - 2] = stack[top - 1];
-                --top;
-            }
-            else {
-                ret = merge_at_<Tag>(arr, stack, top - 2, buffer);
-
-                if (NPY_UNLIKELY(ret < 0)) {
-                    return ret;
-                }
-
-                stack[top - 2].l += C;
-                --top;
-            }
-        }
-        else if (1 < top && B <= C) {
-            ret = merge_at_<Tag>(arr, stack, top - 2, buffer);
-
+    if (*stack_ptr > 0) {
+        npy_intp s1 = stack[*stack_ptr - 1].s;
+        npy_intp n1 = stack[*stack_ptr - 1].l;
+        int power = powerloop(s1, n1, n2, total);
+        while (*stack_ptr > 1 && stack[*stack_ptr - 2].power > power) {
+            ret = merge_at_<Tag>(arr, stack, *stack_ptr - 2, buffer);
             if (NPY_UNLIKELY(ret < 0)) {
                 return ret;
             }
-
-            stack[top - 2].l += C;
-            --top;
+            stack[*stack_ptr - 2].l += stack[*stack_ptr - 1].l;
+            --(*stack_ptr);
         }
-        else {
-            break;
+        /* Set the power for the last run on the stack */
+        if (*stack_ptr > 0) {
+            stack[*stack_ptr - 1].power = power;
         }
     }
-
-    *stack_ptr = top;
     return 0;
 }
 
@@ -499,15 +498,14 @@ timsort_(void *start, npy_intp num)
 
     for (l = 0; l < num;) {
         n = count_run_<Tag>((type *)start, l, num, minrun);
+        ret = found_new_run_<Tag>((type *)start, stack, &stack_ptr, n, num, &buffer);
+        if (NPY_UNLIKELY(ret < 0))
+            goto cleanup;
+
+        // Push the new run onto the stack.
         stack[stack_ptr].s = l;
         stack[stack_ptr].l = n;
         ++stack_ptr;
-        ret = try_collapse_<Tag>((type *)start, stack, &stack_ptr, &buffer);
-
-        if (NPY_UNLIKELY(ret < 0)) {
-            goto cleanup;
-        }
-
         l += n;
     }
 


### PR DESCRIPTION
This PR implements [Powersort](https://www.wild-inter.net/posts/powersort-in-python-3.11). It is an algorithm based on the currently used Timsort and has already been implemented in [CPython](https://github.com/python/cpython/issues/78742) and [PyPy](https://foss.heptapod.net/pypy/pypy/-/blob/branch/default/rpython/rlib/listsort.py).

Powersort is a drop in replacement with the same functionality, which we verified with `spin test -m full`.

We tested benchmarked the implementation on [real-world data](https://www.wild-inter.net/posts/pycon23-sorting-benchmark) and archieved a [strong improvement](https://github.com/user-attachments/assets/0772e8fb-eacb-45ef-bec4-63a6e9e5435a).


So far, other data types than [numeric sorts](https://github.com/numpy/numpy/blob/aa4f974c2f9905ac05b395a35bf14ea4d0fb9499/numpy/_core/src/npysort/timsort.cpp#L92) (i.e. string and generic) are not implemented, as well as argsort for each.