### PR TITLE
runstack size powersort

### DIFF
--- a/numpy/_core/src/npysort/timsort.cpp
+++ b/numpy/_core/src/npysort/timsort.cpp
@@ -39,8 +39,8 @@
 #include <cstdlib>
 #include <utility>
 
-/* enough for 32 * 1.618 ** 128 elements */
-#define TIMSORT_STACK_SIZE 128
+/* enough for 32 * 2 ** 90 elements */
+#define TIMSORT_STACK_SIZE 90
 
 static npy_intp
 compute_min_run(npy_intp num)


### PR DESCRIPTION
 (2^90 >= 1.618^128, so we can sort the same sizes as before)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
